### PR TITLE
feat: Add checkpoint task type

### DIFF
--- a/docs/task-structure.md
+++ b/docs/task-structure.md
@@ -14,6 +14,8 @@ Tasks in tasks.json have the following structure:
   - Dependencies are displayed with status indicators (✅ for completed, ⏱️ for pending)
   - This helps quickly identify which prerequisite tasks are blocking work
 - `priority`: Importance level of the task (Example: `"high"`, `"medium"`, `"low"`)
+- `type` (optional): Describes the nature of the task. Can be `"standard"` (default if omitted) or `"checkpoint"`. Checkpoints are tasks that block progress until specific, quantifiable acceptance criteria are met.
+- `acceptanceCriteria` (string): Mandatory if `type` is `"checkpoint"`. Describes the conditions that must be met for the checkpoint to be considered complete.
 - `details`: In-depth implementation instructions (Example: `"Use GitHub client ID/secret, handle callback, set session token."`)
 - `testStrategy`: Verification approach (Example: `"Deploy and call endpoint to confirm 'Hello World' response."`)
 - `subtasks`: List of smaller, more specific tasks that make up the main task (Example: `[{"id": 1, "title": "Configure OAuth", ...}]`)
@@ -28,6 +30,8 @@ Individual task files follow this format:
 # Status: <status>
 # Dependencies: <comma-separated list of dependency IDs>
 # Priority: <priority>
+# Type: <type>
+# Acceptance Criteria: <criteria>
 # Description: <brief description>
 # Details:
 <detailed implementation notes>
@@ -117,6 +121,31 @@ The `show` command:
 - For subtasks, shows parent task relationship
 - Provides contextual action suggestions based on the task's state
 - Works with both regular tasks and subtasks (using the format taskId.subtaskId)
+
+### Checkpoint Tasks
+
+Checkpoint tasks are a special type of task designed to ensure that key milestones are verifiably met before further work proceeds. They act as gates, blocking dependent tasks until their specific, quantifiable acceptance criteria are satisfied.
+
+**Purpose:**
+- **Block Progress:** Prevent work on dependent tasks until critical prerequisites are confirmed complete.
+- **Ensure Quality:** Guarantee that key project milestones meet defined standards before moving forward.
+- **Verifiable Milestones:** Provide clear, demonstrable proof that a certain stage of development or a specific functionality has been successfully achieved.
+
+**Defining `acceptanceCriteria`:**
+Acceptance criteria are crucial for checkpoint tasks and must be:
+- **Demonstrable:** It should be possible to clearly show that the criteria have been met (e.g., "User can successfully log in with valid credentials and is redirected to the dashboard").
+- **Quantifiable:** Where possible, criteria should be measurable (e.g., "API response time for endpoint X is less than 200ms for 99% of requests under normal load conditions").
+- **Specific:** Avoid vague language. Clearly state what constitutes successful completion.
+
+**Typical Workflow:**
+1. A checkpoint task is created with clear `acceptanceCriteria`.
+2. Work progresses on tasks that are prerequisites for the checkpoint.
+3. Once prerequisite tasks are done, the `acceptanceCriteria` for the checkpoint are actively verified (e.g., through testing, demonstration, or code review).
+4. Only after the `acceptanceCriteria` are confirmed to be met can the checkpoint task be marked as `done`.
+5. Tasks that depend on the checkpoint can now proceed.
+
+**Status Lifecycle:**
+Checkpoint tasks primarily use the `pending` and `done` statuses. Moving a checkpoint task to `done` (e.g., via `set-status --status=done --id=<task-id>`) implies that its `acceptanceCriteria` have been rigorously verified and met. The exact mechanism for this confirmation and potential links to automated testing or review processes will be detailed in future updates to the Task Master system.
 
 ## Best Practices for AI-Driven Development
 

--- a/scripts/modules/task-manager/set-task-status.js
+++ b/scripts/modules/task-manager/set-task-status.js
@@ -14,13 +14,14 @@ import generateTaskFiles from './generate-task-files.js';
  * @param {string} tasksPath - Path to the tasks.json file
  * @param {string} taskIdInput - Task ID(s) to update
  * @param {string} newStatus - New status
- * @param {Object} options - Additional options (mcpLog for MCP mode)
+ * @param {Object} options - Additional options (mcpLog for MCP mode, criteriaMet for checkpoints)
  * @returns {Object|undefined} Result object in MCP mode, undefined in CLI mode
  */
 async function setTaskStatus(tasksPath, taskIdInput, newStatus, options = {}) {
 	try {
+		const { mcpLog, criteriaMet = false } = options;
 		// Determine if we're in MCP mode by checking for mcpLog
-		const isMcpMode = !!options?.mcpLog;
+		const isMcpMode = !!mcpLog;
 
 		// Only display UI elements if not in MCP mode
 		if (!isMcpMode) {
@@ -47,7 +48,7 @@ async function setTaskStatus(tasksPath, taskIdInput, newStatus, options = {}) {
 
 		// Update each task
 		for (const id of taskIds) {
-			await updateSingleTaskStatus(tasksPath, id, newStatus, data, !isMcpMode);
+			await updateSingleTaskStatus(tasksPath, id, newStatus, data, !isMcpMode, criteriaMet);
 			updatedTasks.push(id);
 		}
 
@@ -61,7 +62,7 @@ async function setTaskStatus(tasksPath, taskIdInput, newStatus, options = {}) {
 		// Generate individual task files
 		log('info', 'Regenerating task files...');
 		await generateTaskFiles(tasksPath, path.dirname(tasksPath), {
-			mcpLog: options.mcpLog
+			mcpLog: mcpLog // Use destructured mcpLog
 		});
 
 		// Display success message - only in CLI mode
@@ -94,11 +95,11 @@ async function setTaskStatus(tasksPath, taskIdInput, newStatus, options = {}) {
 		log('error', `Error setting task status: ${error.message}`);
 
 		// Only show error UI in CLI mode
-		if (!options?.mcpLog) {
+		if (!mcpLog) { // Use destructured mcpLog
 			console.error(chalk.red(`Error: ${error.message}`));
 
 			// Pass session to getDebugFlag
-			if (getDebugFlag(options?.session)) {
+			if (getDebugFlag(options?.session)) { // options.session is still valid if needed
 				// Use getter
 				console.error(error);
 			}

--- a/scripts/modules/task-manager/update-single-task-status.js
+++ b/scripts/modules/task-manager/update-single-task-status.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-import { log } from '../utils.js';
+import { log, promptYesNo } from '../utils.js';
 
 /**
  * Update the status of a single task
@@ -9,13 +9,15 @@ import { log } from '../utils.js';
  * @param {string} newStatus - New status
  * @param {Object} data - Tasks data
  * @param {boolean} showUi - Whether to show UI elements
+ * @param {boolean} criteriaMet - Whether acceptance criteria have been confirmed met (for checkpoints)
  */
 async function updateSingleTaskStatus(
 	tasksPath,
 	taskIdInput,
 	newStatus,
 	data,
-	showUi = true
+	showUi = true,
+	criteriaMet = false
 ) {
 	// Check if it's a subtask (e.g., "1.2")
 	if (taskIdInput.includes('.')) {
@@ -87,6 +89,29 @@ async function updateSingleTaskStatus(
 
 		if (!task) {
 			throw new Error(`Task ${taskId} not found`);
+		}
+
+		// Checkpoint-specific logic for 'done' status
+		if (
+			task.type === 'checkpoint' &&
+			(newStatus.toLowerCase() === 'done' || newStatus.toLowerCase() === 'completed')
+		) {
+			let confirmedCriteriaMet = criteriaMet;
+			if (!confirmedCriteriaMet && showUi) {
+				// CLI mode, criteriaMet flag not passed, so prompt user
+				const question = `Have the acceptance criteria for checkpoint task '${task.title}' (ID: ${task.id}) been demonstrably met? (yes/no)`;
+				// Ensure promptYesNo is awaited as it likely performs I/O.
+				confirmedCriteriaMet = await promptYesNo(question);
+			}
+
+			if (!confirmedCriteriaMet) {
+				const errorMessage = `Acceptance criteria for checkpoint ${task.id} ('${task.title}') must be met and confirmed before marking as done.`;
+				log('warn', errorMessage);
+				// This error will be caught by the calling function (setTaskStatus)
+				// which will handle CLI vs MCP error reporting.
+				throw new Error(errorMessage);
+			}
+			log('info', `Acceptance criteria for checkpoint ${task.id} confirmed as met.`);
 		}
 
 		// Update the task status


### PR DESCRIPTION
This commit introduces a new task type called "checkpoint". Checkpoints act as gates in a project, blocking dependent tasks until specific, demonstrable, and quantifiable acceptance criteria are met.

Key changes:

1.  **Task Structure:**
    *   Added an optional `type` field to tasks (`standard` or `checkpoint`).
    *   Added `acceptanceCriteria` string field, mandatory for checkpoint tasks.
    *   Updated `docs/task-structure.md` with details on these fields and checkpoint task usage.

2.  **Task Creation (`add-task.js`):**
    *   `addTask` now accepts a `taskType` parameter.
    *   AI prompts and Zod schema (`AiTaskDataSchema`) updated to handle `acceptanceCriteria` for checkpoints.
    *   Validation added to ensure checkpoints have acceptance criteria.

3.  **Task Status (`set-task-status.js`, `update-single-task-status.js`):**
    *   When setting a checkpoint task to `done`, confirmation that `acceptanceCriteria` have been met is now required.
    *   This is handled via a new `--criteria-met` flag for the `set-status` CLI command or an interactive prompt for CLI users if the flag is not provided.
    *   In non-interactive mode, the `criteriaMet` flag (passed as an option) is required to mark a checkpoint as done.

4.  **Dependency Logic (`find-next-task.js`):**
    *   No changes were needed as the existing logic (dependencies must be `done`) works correctly with the new checkpoint completion integrity enforced by `set-task-status`.

5.  **CLI and UI (`commands.js`, `ui.js`):**
    *   `task-master add` command now supports `--type <taskType>` to create checkpoints.
    *   `task-master set-status` command now supports `--criteria-met` for checkpoint completion.
    *   Task display (e.g., in `show`, `next`) now indicates if a task is a checkpoint and shows its `acceptanceCriteria`.
    *   Help documentation updated for new CLI options.

6.  **Unit Tests (`task-manager.test.js`):**
    *   Added comprehensive unit tests for:
        *   Creating standard and checkpoint tasks.
        *   Setting status for checkpoints (including `criteriaMet` and prompt logic).
        *   `find-next-task` behavior with checkpoint dependencies.